### PR TITLE
Add IterL3MuonNoID variable

### DIFF
--- a/ntupler/BuildFile.xml
+++ b/ntupler/BuildFile.xml
@@ -15,6 +15,3 @@
 <use name="RecoMuon/DetLayers"/>
 <!--   <flags   EDM_PLUGIN="1"/> -->
 <flags EDM_PLUGIN="1"/>
-<export>
-  <lib   name="1"/>
-</export>

--- a/ntupler/interface/ntupler.h
+++ b/ntupler/interface/ntupler.h
@@ -69,44 +69,46 @@ private:
 
   //For Rerun (Fill_IterL3*)
   void Fill_IterL3(const edm::Event &iEvent);
+  void Fill_IterL3MuonNoID(const edm::Event &iEvent);
 
-  edm::EDGetTokenT< std::vector<reco::Muon> >             Token_OfflineMuon;
-  edm::EDGetTokenT< reco::VertexCollection >              Token_OfflineVertex;
-  edm::EDGetTokenT<edm::TriggerResults>                   Token_TriggerResults;
-  edm::EDGetTokenT<trigger::TriggerEvent>                 Token_TriggerEvent;
-  edm::EDGetTokenT<edm::TriggerResults>                   Token_MyTriggerResults;
-  edm::EDGetTokenT<trigger::TriggerEvent>                 Token_MyTriggerEvent;
+  edm::EDGetTokenT< std::vector<reco::Muon> >                Token_OfflineMuon;
+  edm::EDGetTokenT< reco::VertexCollection >                 Token_OfflineVertex;
+  edm::EDGetTokenT< edm::TriggerResults >                    Token_TriggerResults;
+  edm::EDGetTokenT< trigger::TriggerEvent >                  Token_TriggerEvent;
+  edm::EDGetTokenT< edm::TriggerResults >                    Token_MyTriggerResults;
+  edm::EDGetTokenT< trigger::TriggerEvent >                  Token_MyTriggerEvent;
 
-  edm::EDGetTokenT<reco::RecoChargedCandidateCollection>  Token_L3Muon;
-  edm::EDGetTokenT<reco::RecoChargedCandidateCollection>  Token_L2Muon;
-  edm::EDGetTokenT<l1t::MuonBxCollection>                 Token_L1Muon;
-  edm::EDGetTokenT<reco::RecoChargedCandidateCollection>  Token_TkMuon;
+  edm::EDGetTokenT< reco::RecoChargedCandidateCollection >   Token_L3Muon;
+  edm::EDGetTokenT< reco::RecoChargedCandidateCollection >   Token_L2Muon;
+  edm::EDGetTokenT< l1t::MuonBxCollection >                  Token_L1Muon;
+  edm::EDGetTokenT< reco::RecoChargedCandidateCollection >   Token_TkMuon;
 
-  edm::EDGetTokenT< std::vector<reco::MuonTrackLinks> >   Token_IterL3OI;
-  edm::EDGetTokenT< std::vector<reco::MuonTrackLinks> >   Token_IterL3IO_L2Seeded;
-  edm::EDGetTokenT< std::vector<reco::Track> >            Token_IterL3IO_FromL1;
-  edm::EDGetTokenT< std::vector<reco::MuonTrackLinks> >   Token_IterL3_FromL2;
+  edm::EDGetTokenT< std::vector<reco::MuonTrackLinks> >      Token_IterL3OI;
+  edm::EDGetTokenT< std::vector<reco::MuonTrackLinks> >      Token_IterL3IO_L2Seeded;
+  edm::EDGetTokenT< std::vector<reco::Track> >               Token_IterL3IO_FromL1;
+  edm::EDGetTokenT< std::vector<reco::MuonTrackLinks> >      Token_IterL3_FromL2;
+  edm::EDGetTokenT< std::vector<reco::Muon> >                Token_IterL3MuonNoID;
 
-  edm::EDGetTokenT<reco::IsoDepositMap>                   Token_ChargedIsoDep;
-  edm::EDGetTokenT<reco::RecoChargedCandidateIsolationMap>Token_NeutralIsoDep;
-  edm::EDGetTokenT<reco::RecoChargedCandidateIsolationMap>Token_PhotonIsoDep;
+  edm::EDGetTokenT< reco::IsoDepositMap >                    Token_ChargedIsoDep;
+  edm::EDGetTokenT< reco::RecoChargedCandidateIsolationMap > Token_NeutralIsoDep;
+  edm::EDGetTokenT< reco::RecoChargedCandidateIsolationMap > Token_PhotonIsoDep;
 
-  edm::EDGetTokenT<double>                                Token_Rho;
-  edm::EDGetTokenT<double>                                Token_OfflineRho;
+  edm::EDGetTokenT< double >                                 Token_Rho;
+  edm::EDGetTokenT< double >                                 Token_OfflineRho;
 
-  edm::EDGetTokenT<double>                                Token_RhoECAL;
-  edm::EDGetTokenT<double>                                Token_RhoHCAL;
+  edm::EDGetTokenT< double >                                 Token_RhoECAL;
+  edm::EDGetTokenT< double >                                 Token_RhoHCAL;
 
-  edm::EDGetTokenT<edm::ValueMap<float>>                  Token_OfflineECALPFIso03;
-  edm::EDGetTokenT<edm::ValueMap<float>>                  Token_OfflineHCALPFIso03;
-  edm::EDGetTokenT<edm::ValueMap<float>>                  Token_OfflineECALPFIso04;
-  edm::EDGetTokenT<edm::ValueMap<float>>                  Token_OfflineHCALPFIso04;
+  edm::EDGetTokenT< edm::ValueMap<float> >                   Token_OfflineECALPFIso03;
+  edm::EDGetTokenT< edm::ValueMap<float> >                   Token_OfflineHCALPFIso03;
+  edm::EDGetTokenT< edm::ValueMap<float> >                   Token_OfflineECALPFIso04;
+  edm::EDGetTokenT< edm::ValueMap<float> >                   Token_OfflineHCALPFIso04;
 
-  edm::EDGetTokenT<LumiScalersCollection>                 Token_LumiScaler;
-  edm::EDGetTokenT<LumiScalersCollection>                 Token_OfflineLumiScaler;
-  edm::EDGetTokenT< std::vector<PileupSummaryInfo> >      Token_PUSummaryInfo;
-  edm::EDGetTokenT< GenEventInfoProduct >                 Token_GenEventInfo;
-  edm::EDGetTokenT<reco::GenParticleCollection>           Token_GenParticle;
+  edm::EDGetTokenT< LumiScalersCollection >                  Token_LumiScaler;
+  edm::EDGetTokenT< LumiScalersCollection >                  Token_OfflineLumiScaler;
+  edm::EDGetTokenT< std::vector<PileupSummaryInfo> >         Token_PUSummaryInfo;
+  edm::EDGetTokenT< GenEventInfoProduct >                    Token_GenEventInfo;
+  edm::EDGetTokenT< reco::GenParticleCollection >            Token_GenParticle;
 
   TTree *ntuple;
   static const int ArrSize = 2000;
@@ -313,5 +315,16 @@ private:
   double IterL3_FromL2_GL_Eta[ArrSize];
   double IterL3_FromL2_GL_Phi[ArrSize];
   double IterL3_FromL2_GL_Charge[ArrSize];
+
+  int nIterL3MuonNoID;
+  double IterL3MuonNoID_Pt[ArrSize];
+  double IterL3MuonNoID_Eta[ArrSize];
+  double IterL3MuonNoID_Phi[ArrSize];
+  double IterL3MuonNoID_Charge[ArrSize];
+  int IterL3MuonNoID_IsGLB[ArrSize];
+  int IterL3MuonNoID_IsSTA[ArrSize];
+  int IterL3MuonNoID_IsTRK[ArrSize];
+
+
 
 };

--- a/ntupler/python/customizerForNtupler.py
+++ b/ntupler/python/customizerForNtupler.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+def customizerForNtuplerHLT(process, newProcessName = "MYHLT"):
+    if hasattr(process, "DQMOutput"):
+        del process.DQMOutput
+
+        flag_ReRun = True
+
+        from TSNtuple.ntupler.ntupler_cfi import ntuplerBase
+
+        process.ntupler = ntuplerBase.clone()
+        process.ntupler.OfflineMuon = cms.untracked.InputTag("muons")
+        process.ntupler.L3Muon = cms.untracked.InputTag("hltIterL3MuonCandidates")
+        process.ntupler.L2Muon = cms.untracked.InputTag("hltL2MuonCandidates")
+        process.ntupler.TriggerResults = cms.untracked.InputTag("TriggerResults", "", "HLT")
+        process.ntupler.TriggerEvent = cms.untracked.InputTag("hltTriggerSummaryAOD", "", "HLT")
+        process.ntupler.OfflineLumiScaler = cms.untracked.InputTag("scalersRawToDigi")
+
+        if flag_ReRun: # -- after HLT re-run -- #
+          process.ntupler.L1Muon           = cms.untracked.InputTag("hltGtStage2Digis", "Muon", newProcessName)
+          process.ntupler.MyTriggerResults = cms.untracked.InputTag("TriggerResults", "", newProcessName) # -- result after rerun HLT -- #
+          process.ntupler.MyTriggerEvent   = cms.untracked.InputTag("hltTriggerSummaryAOD", "", newProcessName) # -- result after rerun HLT -- #
+          process.ntupler.LumiScaler       = cms.untracked.InputTag("hltScalersRawToDigi", "", newProcessName)
+          process.ntupler.IterL3MuonNoID   = cms.untracked.InputTag("hltIterL3MuonsNoID", "", newProcessName)
+        else: # -- without HLT re-run -- #
+          process.ntupler.L1Muon = cms.untracked.InputTag("gmtStage2Digis", "Muon", "RECO")
+          process.ntupler.MyTriggerResults = cms.untracked.InputTag("TriggerResults")
+          process.ntupler.MyTriggerEvent = cms.untracked.InputTag("hltTriggerSummaryAOD")
+          process.ntupler.LumiScaler = cms.untracked.InputTag("hltScalersRawToDigi")
+
+        process.TFileService = cms.Service("TFileService",
+          fileName = cms.string("ntuple.root"),
+          closeFileFast = cms.untracked.bool(False),
+          )
+
+        process.mypath = cms.EndPath(process.ntupler)
+
+

--- a/ntupler/python/ntupler_cfi.py
+++ b/ntupler/python/ntupler_cfi.py
@@ -37,4 +37,5 @@ ntuplerBase = cms.EDAnalyzer("ntupler",
   IterL3IO_L2Seeded  = cms.untracked.InputTag("hltL3MuonsIterL3IO", "", "MYHLT"),
   IterL3IO_FromL1    = cms.untracked.InputTag("hltIter2IterL3FromL1MuonMerged", "", "MYHLT"),
   IterL3_FromL2      = cms.untracked.InputTag("hltIterL3MuonsFromL2LinksCombination", "", "MYHLT"),
+  IterL3MuonNoID     = cms.untracked.InputTag("hltIterL3MuonsNoID", "", "MYHLT"),
 )

--- a/ntupler/src/ntupler.cc
+++ b/ntupler/src/ntupler.cc
@@ -53,38 +53,39 @@ using namespace reco;
 using namespace edm;
 
 ntupler::ntupler(const edm::ParameterSet& iConfig):
-Token_OfflineMuon           ( consumes< std::vector<reco::Muon> >         (iConfig.getUntrackedParameter<edm::InputTag>("OfflineMuon")) ),
-Token_OfflineVertex         ( consumes< reco::VertexCollection >        (iConfig.getUntrackedParameter<edm::InputTag>("OfflineVertex")) ),
-Token_TriggerResults        ( consumes<edm::TriggerResults>           (iConfig.getUntrackedParameter<edm::InputTag>("TriggerResults")) ),
-Token_TriggerEvent          ( consumes<trigger::TriggerEvent>         (iConfig.getUntrackedParameter<edm::InputTag>("TriggerEvent")) ),
-Token_MyTriggerResults      ( consumes<edm::TriggerResults>           (iConfig.getUntrackedParameter<edm::InputTag>("MyTriggerResults")) ),
-Token_MyTriggerEvent        ( consumes<trigger::TriggerEvent>         (iConfig.getUntrackedParameter<edm::InputTag>("MyTriggerEvent")) ),
-Token_L3Muon                ( consumes<reco::RecoChargedCandidateCollection>  (iConfig.getUntrackedParameter<edm::InputTag>("L3Muon")) ),
-Token_L2Muon                ( consumes<reco::RecoChargedCandidateCollection>  (iConfig.getUntrackedParameter<edm::InputTag>("L2Muon")) ),
-Token_L1Muon                ( consumes<l1t::MuonBxCollection>           (iConfig.getUntrackedParameter<edm::InputTag>("L1Muon")) ),
-Token_TkMuon                ( consumes<reco::RecoChargedCandidateCollection>  (iConfig.getUntrackedParameter<edm::InputTag>("TkMuon")) ),
+Token_OfflineMuon        ( consumes< std::vector<reco::Muon> >                (iConfig.getUntrackedParameter<edm::InputTag>("OfflineMuon"       )) ),
+Token_OfflineVertex      ( consumes< reco::VertexCollection >                 (iConfig.getUntrackedParameter<edm::InputTag>("OfflineVertex"     )) ),
+Token_TriggerResults     ( consumes< edm::TriggerResults >                    (iConfig.getUntrackedParameter<edm::InputTag>("TriggerResults"    )) ),
+Token_TriggerEvent       ( consumes< trigger::TriggerEvent >                  (iConfig.getUntrackedParameter<edm::InputTag>("TriggerEvent"      )) ),
+Token_MyTriggerResults   ( consumes< edm::TriggerResults >                    (iConfig.getUntrackedParameter<edm::InputTag>("MyTriggerResults"  )) ),
+Token_MyTriggerEvent     ( consumes< trigger::TriggerEvent >                  (iConfig.getUntrackedParameter<edm::InputTag>("MyTriggerEvent"    )) ),
+Token_L3Muon             ( consumes< reco::RecoChargedCandidateCollection >   (iConfig.getUntrackedParameter<edm::InputTag>("L3Muon"            )) ),
+Token_L2Muon             ( consumes< reco::RecoChargedCandidateCollection >   (iConfig.getUntrackedParameter<edm::InputTag>("L2Muon"            )) ),
+Token_L1Muon             ( consumes< l1t::MuonBxCollection  >                 (iConfig.getUntrackedParameter<edm::InputTag>("L1Muon"            )) ),
+Token_TkMuon             ( consumes< reco::RecoChargedCandidateCollection >   (iConfig.getUntrackedParameter<edm::InputTag>("TkMuon"            )) ),
 
-Token_IterL3OI              ( consumes< std::vector<reco::MuonTrackLinks> >  (iConfig.getUntrackedParameter<edm::InputTag>("IterL3OI")) ),
-Token_IterL3IO_L2Seeded     ( consumes< std::vector<reco::MuonTrackLinks> >  (iConfig.getUntrackedParameter<edm::InputTag>("IterL3IO_L2Seeded")) ),
-Token_IterL3IO_FromL1       ( consumes< std::vector<reco::Track> >           (iConfig.getUntrackedParameter<edm::InputTag>("IterL3IO_FromL1")) ),
-Token_IterL3_FromL2         ( consumes< std::vector<reco::MuonTrackLinks> >  (iConfig.getUntrackedParameter<edm::InputTag>("IterL3_FromL2")) ),
+Token_IterL3OI           ( consumes< std::vector<reco::MuonTrackLinks> >      (iConfig.getUntrackedParameter<edm::InputTag>("IterL3OI"          )) ),
+Token_IterL3IO_L2Seeded  ( consumes< std::vector<reco::MuonTrackLinks> >      (iConfig.getUntrackedParameter<edm::InputTag>("IterL3IO_L2Seeded" )) ),
+Token_IterL3IO_FromL1    ( consumes< std::vector<reco::Track> >               (iConfig.getUntrackedParameter<edm::InputTag>("IterL3IO_FromL1"   )) ),
+Token_IterL3_FromL2      ( consumes< std::vector<reco::MuonTrackLinks> >      (iConfig.getUntrackedParameter<edm::InputTag>("IterL3_FromL2"     )) ),
+Token_IterL3MuonNoID     ( consumes< std::vector<reco::Muon> >                (iConfig.getUntrackedParameter<edm::InputTag>("IterL3MuonNoID"    )) ),
 
-Token_ChargedIsoDep         ( consumes<reco::IsoDepositMap>           (iConfig.getUntrackedParameter<edm::InputTag>("ChargedIsoDep")) ),
-Token_NeutralIsoDep         ( consumes<reco::RecoChargedCandidateIsolationMap>  (iConfig.getUntrackedParameter<edm::InputTag>("NeutralIsoDep")) ),
-Token_PhotonIsoDep          ( consumes<reco::RecoChargedCandidateIsolationMap>  (iConfig.getUntrackedParameter<edm::InputTag>("PhotonIsoDep")) ),
-Token_Rho                   ( consumes<double>                  (iConfig.getUntrackedParameter<edm::InputTag>("Rho")) ),
-Token_OfflineRho            ( consumes<double>                  (iConfig.getUntrackedParameter<edm::InputTag>("OfflineRho")) ),
-Token_RhoECAL               ( consumes<double>                  (iConfig.getUntrackedParameter<edm::InputTag>("RhoECAL")) ),
-Token_RhoHCAL               ( consumes<double>                  (iConfig.getUntrackedParameter<edm::InputTag>("RhoHCAL")) ),
-Token_OfflineECALPFIso03    ( consumes<edm::ValueMap<float>>          (iConfig.getUntrackedParameter<edm::InputTag>("OfflineECALPFIso03")) ),
-Token_OfflineHCALPFIso03    ( consumes<edm::ValueMap<float>>          (iConfig.getUntrackedParameter<edm::InputTag>("OfflineHCALPFIso03")) ),
-Token_OfflineECALPFIso04    ( consumes<edm::ValueMap<float>>          (iConfig.getUntrackedParameter<edm::InputTag>("OfflineECALPFIso04")) ),
-Token_OfflineHCALPFIso04    ( consumes<edm::ValueMap<float>>          (iConfig.getUntrackedParameter<edm::InputTag>("OfflineHCALPFIso04")) ),
-Token_LumiScaler            ( consumes<LumiScalersCollection>           (iConfig.getUntrackedParameter<edm::InputTag>("LumiScaler")) ),
-Token_OfflineLumiScaler     ( consumes<LumiScalersCollection>           (iConfig.getUntrackedParameter<edm::InputTag>("OfflineLumiScaler")) ),
-Token_PUSummaryInfo         ( consumes< std::vector<PileupSummaryInfo> >    (iConfig.getUntrackedParameter<edm::InputTag>("PUSummaryInfo")) ),
-Token_GenEventInfo          ( consumes< GenEventInfoProduct >         (iConfig.getUntrackedParameter<edm::InputTag>("GenEventInfo")) ),
-Token_GenParticle           ( consumes<reco::GenParticleCollection>       (iConfig.getUntrackedParameter<edm::InputTag>("GenParticle")) )
+Token_ChargedIsoDep      ( consumes< reco::IsoDepositMap >                    (iConfig.getUntrackedParameter<edm::InputTag>("ChargedIsoDep"     )) ),
+Token_NeutralIsoDep      ( consumes< reco::RecoChargedCandidateIsolationMap > (iConfig.getUntrackedParameter<edm::InputTag>("NeutralIsoDep"     )) ),
+Token_PhotonIsoDep       ( consumes< reco::RecoChargedCandidateIsolationMap > (iConfig.getUntrackedParameter<edm::InputTag>("PhotonIsoDep"      )) ),
+Token_Rho                ( consumes< double >                                 (iConfig.getUntrackedParameter<edm::InputTag>("Rho"               )) ),
+Token_OfflineRho         ( consumes< double >                                 (iConfig.getUntrackedParameter<edm::InputTag>("OfflineRho"        )) ),
+Token_RhoECAL            ( consumes< double >                                 (iConfig.getUntrackedParameter<edm::InputTag>("RhoECAL"           )) ),
+Token_RhoHCAL            ( consumes< double >                                 (iConfig.getUntrackedParameter<edm::InputTag>("RhoHCAL"           )) ),
+Token_OfflineECALPFIso03 ( consumes< edm::ValueMap<float> >                   (iConfig.getUntrackedParameter<edm::InputTag>("OfflineECALPFIso03")) ),
+Token_OfflineHCALPFIso03 ( consumes< edm::ValueMap<float> >                   (iConfig.getUntrackedParameter<edm::InputTag>("OfflineHCALPFIso03")) ),
+Token_OfflineECALPFIso04 ( consumes< edm::ValueMap<float> >                   (iConfig.getUntrackedParameter<edm::InputTag>("OfflineECALPFIso04")) ),
+Token_OfflineHCALPFIso04 ( consumes< edm::ValueMap<float> >                   (iConfig.getUntrackedParameter<edm::InputTag>("OfflineHCALPFIso04")) ),
+Token_LumiScaler         ( consumes< LumiScalersCollection >                  (iConfig.getUntrackedParameter<edm::InputTag>("LumiScaler"        )) ),
+Token_OfflineLumiScaler  ( consumes< LumiScalersCollection >                  (iConfig.getUntrackedParameter<edm::InputTag>("OfflineLumiScaler" )) ),
+Token_PUSummaryInfo      ( consumes< std::vector<PileupSummaryInfo> >         (iConfig.getUntrackedParameter<edm::InputTag>("PUSummaryInfo"     )) ),
+Token_GenEventInfo       ( consumes< GenEventInfoProduct >                    (iConfig.getUntrackedParameter<edm::InputTag>("GenEventInfo"      )) ),
+Token_GenParticle        ( consumes< reco::GenParticleCollection >            (iConfig.getUntrackedParameter<edm::InputTag>("GenParticle"       )) )
 {
 
 }
@@ -166,6 +167,7 @@ void ntupler::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup)
   this->Fill_L1Muon(iEvent);
 
   this->Fill_IterL3(iEvent);
+  this->Fill_IterL3MuonNoID( iEvent );
 
   if( !iEvent.isRealData() ) this->Fill_GenParticle(iEvent);
 
@@ -416,6 +418,19 @@ void ntupler::Init()
     this->IterL3_FromL2_GL_Charge[i] = -999;
   }
 
+  this->nIterL3MuonNoID = 0;
+  for (int i=0; i<this->ArrSize; ++i) {
+    this->IterL3MuonNoID_Pt[i] = -999;
+    this->IterL3MuonNoID_Eta[i] = -999;
+    this->IterL3MuonNoID_Phi[i] = -999;
+    this->IterL3MuonNoID_Charge[i] = -999;
+
+    this->IterL3MuonNoID_IsGLB[i] = 0;
+    this->IterL3MuonNoID_IsSTA[i] = 0;
+    this->IterL3MuonNoID_IsTRK[i] = 0;
+  }
+
+
 }
 
 void ntupler::Make_Branch()
@@ -612,6 +627,13 @@ void ntupler::Make_Branch()
   this->ntuple->Branch("IterL3_FromL2_GL_Phi", &IterL3_FromL2_GL_Phi, "IterL3_FromL2_GL_Phi[nIterL3_FromL2]/D");
   this->ntuple->Branch("IterL3_FromL2_GL_Charge", &IterL3_FromL2_GL_Charge, "IterL3_FromL2_GL_Charge[nIterL3_FromL2]/D");
 
+  this->ntuple->Branch("nIterL3MuonNoID", &nIterL3MuonNoID, "nIterL3MuonNoID/I");
+  this->ntuple->Branch("IterL3MuonNoID_Pt", &IterL3MuonNoID_Pt, "IterL3MuonNoID_Pt[nIterL3_FromL2]/D");
+  this->ntuple->Branch("IterL3MuonNoID_Eta", &IterL3MuonNoID_Eta, "IterL3MuonNoID_Eta[nIterL3_FromL2]/D");
+  this->ntuple->Branch("IterL3MuonNoID_Phi", &IterL3MuonNoID_Phi, "IterL3MuonNoID_Phi[nIterL3_FromL2]/D");
+  this->ntuple->Branch("IterL3MuonNoID_IsGLB", &IterL3MuonNoID_IsGLB, "IterL3MuonNoID_IsGLB[nIterL3_FromL2]/I");
+  this->ntuple->Branch("IterL3MuonNoID_IsSTA", &IterL3MuonNoID_IsSTA, "IterL3MuonNoID_IsSTA[nIterL3_FromL2]/I");
+  this->ntuple->Branch("IterL3MuonNoID_IsTRK", &IterL3MuonNoID_IsTRK, "IterL3MuonNoID_IsTRK[nIterL3_FromL2]/I");
 }
 
 void ntupler::Fill_Muon(const edm::Event &iEvent)
@@ -1163,6 +1185,30 @@ void ntupler::Fill_IterL3(const edm::Event &iEvent)
     }
     this->nIterL3_FromL2 = _nIterL3_FromL2;
   }
+
+}
+
+void ntupler::Fill_IterL3MuonNoID(const edm::Event &iEvent) {
+  edm::Handle< std::vector<reco::Muon> > Handle_IterL3MuonNoID;
+  if( iEvent.getByToken( Token_IterL3MuonNoID, Handle_IterL3MuonNoID) ) {
+    int _nIterL3MuonNoID = 0;
+    for( auto i=0U; i<Handle_IterL3MuonNoID->size(); ++i ) {
+      const auto& muon(Handle_IterL3MuonNoID->at(i));
+
+      this->IterL3MuonNoID_Pt[_nIterL3MuonNoID] = muon.pt();
+      this->IterL3MuonNoID_Eta[_nIterL3MuonNoID] = muon.eta();
+      this->IterL3MuonNoID_Phi[_nIterL3MuonNoID] = muon.phi();
+      this->IterL3MuonNoID_Charge[_nIterL3MuonNoID] = muon.charge();
+
+      if( muon.isGlobalMuon() )     this->IterL3MuonNoID_IsGLB[_nIterL3MuonNoID] = 1;
+      if( muon.isStandAloneMuon() ) this->IterL3MuonNoID_IsSTA[_nIterL3MuonNoID] = 1;
+      if( muon.isTrackerMuon() )    this->IterL3MuonNoID_IsTRK[_nIterL3MuonNoID] = 1;
+
+      _nIterL3MuonNoID++;
+    } // -- end of muon iteration
+
+    this->nIterL3MuonNoID = _nIterL3MuonNoID;
+  } // -- if getByToken is valid
 
 }
 


### PR DESCRIPTION
- Add IterL3MuonsNoID (reco::Muon) variables before applying ID
- add a customizer for the ntupler that can be added in the HLT config.